### PR TITLE
WIP: Introduce testing

### DIFF
--- a/kubernetes-dns-reverse-proxy.go
+++ b/kubernetes-dns-reverse-proxy.go
@@ -1,236 +1,55 @@
 package main
 
 import (
-	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
-	"net"
 	"net/http"
-	"net/http/httputil"
-	"os"
-	"path"
-	"strings"
 	"time"
 
-	"github.com/newsdev/kubernetes-dns-reverse-proxy/director"
-	"github.com/newsdev/kubernetes-dns-reverse-proxy/httpwrapper"
+	"github.com/newsdev/kubernetes-dns-reverse-proxy/router"
 )
 
-var config struct {
-	address, statusAddress        string
-	domainSuffixes                string
-	routesFilename                string
-	concurrency, compressionLevel int
-	timeout                       time.Duration
-	validateRoutes                bool
-
-	kubernetes struct {
-		namespace, dnsDomain string
-	}
-
-	static, fallback struct {
-		enable             bool
-		scheme, host, path string
-	}
-}
+var config router.Config
 
 func init() {
-	flag.StringVar(&config.address, "address", ":8080", "address to run the proxy server on")
-	flag.StringVar(&config.statusAddress, "status-address", ":8081", "address to run the status server on")
-	flag.StringVar(&config.domainSuffixes, "domain-suffixes", ".local", "domain suffixes")
-	flag.StringVar(&config.kubernetes.dnsDomain, "kubernetes-dns-domain", "cluster.local", "Kubernetes DNS domain")
-	flag.StringVar(&config.kubernetes.namespace, "kubernetes-namespace", "default", "Kubernetes namespace to server")
-	flag.BoolVar(&config.static.enable, "static", false, "enable static proxy")
-	flag.StringVar(&config.static.scheme, "static-scheme", "http", "static scheme")
-	flag.StringVar(&config.static.host, "static-host", "", "static host")
-	flag.StringVar(&config.static.path, "static-path", "/", "static path")
-	flag.BoolVar(&config.fallback.enable, "fallback", false, "enable fallback proxy")
-	flag.StringVar(&config.fallback.scheme, "fallback-scheme", "http", "fallback scheme")
-	flag.StringVar(&config.fallback.host, "fallback-host", "", "fallback host")
-	flag.StringVar(&config.fallback.path, "fallback-path", "/", "fallback path")
-	flag.StringVar(&config.routesFilename, "routes", "", "path to a routes file")
-	flag.BoolVar(&config.validateRoutes, "validate-routes", false, "validate routes file and exit")
-	flag.IntVar(&config.concurrency, "concurrency", 32, "concurrency per host")
-	flag.IntVar(&config.compressionLevel, "compression-level", 4, "gzip compression level (0 to disable)")
-	flag.DurationVar(&config.timeout, "timeout", time.Second, "dial timeout")
+	// Define flags for the router config object.
+	flag.StringVar(&config.Address, "address", ":8080", "address to run the proxy server on")
+	flag.StringVar(&config.StatusAddress, "status-address", ":8081", "address to run the status server on")
+	flag.StringVar(&config.DomainSuffixesRaw, "domain-suffixes", ".local", "domain suffixes")
+	flag.StringVar(&config.Kubernetes.DNSDomain, "kubernetes-dns-domain", "cluster.local", "Kubernetes DNS domain")
+	flag.StringVar(&config.Kubernetes.Namespace, "kubernetes-namespace", "default", "Kubernetes namespace to server")
+	flag.BoolVar(&config.Static.Enable, "static", false, "enable static proxy")
+	flag.StringVar(&config.Static.Scheme, "static-scheme", "http", "static scheme")
+	flag.StringVar(&config.Static.Host, "static-host", "", "static host")
+	flag.StringVar(&config.Static.Path, "static-path", "/", "static path")
+	flag.BoolVar(&config.Fallback.Enable, "fallback", false, "enable fallback proxy")
+	flag.StringVar(&config.Fallback.Scheme, "fallback-scheme", "http", "fallback scheme")
+	flag.StringVar(&config.Fallback.Host, "fallback-host", "", "fallback host")
+	flag.StringVar(&config.Fallback.Path, "fallback-path", "/", "fallback path")
+	flag.StringVar(&config.RoutesFilename, "routes", "", "path to a routes file")
+	flag.BoolVar(&config.ValidateRoutes, "validate-routes", false, "validate routes file and exit")
+	flag.IntVar(&config.Concurrency, "concurrency", 32, "concurrency per host")
+	flag.IntVar(&config.CompressionLevel, "compression-level", 4, "gzip compression level (0 to disable)")
+	flag.DurationVar(&config.Timeout, "timeout", time.Second, "dial timeout")
 }
 
 func main() {
+	// Parse command-line flags into the router config object.
 	flag.Parse()
 
-	// Set domain suffixes based on the config.
-	domainSuffixes := strings.Split(config.domainSuffixes, ",")
-	log.Println("domain suffixes:", domainSuffixes)
-
-	// Set the kubernetes suffix based on the config.
-	kubernetesSuffix := fmt.Sprintf(".%s.%s", config.kubernetes.namespace, config.kubernetes.dnsDomain)
-	log.Println("kubernetes suffix:", kubernetesSuffix)
-
-	// Create a new director object.
-	d := director.NewDirector()
-
-	// Check for a routes JSON file.
-	if config.validateRoutes || config.routesFilename != "" {
-
-		routesFile, err := os.Open(config.routesFilename)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		routesJSON, err := ioutil.ReadAll(routesFile)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		if err := routesFile.Close(); err != nil {
-			log.Fatal(err)
-		}
-
-		var routes map[string]map[string]string
-		if err := json.Unmarshal(routesJSON, &routes); err != nil {
-			log.Fatal(err)
-		}
-
-		for domain, prefixMap := range routes {
-			for prefix, service := range prefixMap {
-				d.SetService(domain, prefix, service)
-			}
-		}
-
-		log.Println("routes are valid!")
-		if config.validateRoutes {
-			return
-		}
+	mainServer, err := router.NewKubernetesRouter(&config)
+	if err != nil {
+		log.Fatal(err)
 	}
 
-	// Build the reverse proxy HTTP handler.
-	reverseProxy := &httputil.ReverseProxy{
-		// Specify a custom transport which rate limits requests and compresses responses.
-		Transport: &httpwrapper.Transport{
-			MaxConcurrencyPerHost: config.concurrency,
-			CompressionLevel:      config.compressionLevel,
-			Transport: &http.Transport{
-				MaxIdleConnsPerHost: config.concurrency,
-				Dial: func(network, addr string) (net.Conn, error) {
-					return net.DialTimeout(network, addr, config.timeout)
-				},
-			},
-		},
-		// The Director has the opportunity to modify the HTTP request before it
-		// is handed off to the Transport.
-		Director: func(req *http.Request) {
-			// empty director atm
-		},
-	}
-
-	mainServer := &http.Server{
-		Addr: config.address,
-		Handler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-
-			if root, err := d.Service(req.Host, req.URL.Path); err != nil {
-				// The director didn't find a match, handle it gracefully.
-
-				if err != director.NoMatchingServiceError {
-					log.Println("Error:", req.Host, req.URL.Path, err)
-				} else {
-
-					// If NoMatchingServiceError is thrown, check against the domain suffixes, e.g. {service}.local
-					for _, domainSuffix := range domainSuffixes {
-						if root := strings.TrimSuffix(req.Host, domainSuffix); root != req.Host {
-							req.URL.Scheme = "http"
-							req.URL.Host = root + kubernetesSuffix
-							log.Println("Domain Suffix Match:", req.Host, req.URL.Path)
-							reverseProxy.ServeHTTP(w, req)
-							return
-						}
-					}
-
-					// Otherwise, send traffic to the fallback.
-					if config.fallback.enable {
-
-						// Set the URL scheme, host, and path.
-						req.URL.Scheme = config.fallback.scheme
-						req.URL.Host = config.fallback.host
-						req.URL.Path = path.Join(config.fallback.path, req.URL.Path)
-
-						log.Println("Fallback:", req.Host, req.URL.Path, "to", req.URL.Host)
-					} else {
-						log.Println("Error: no route matched and fallback not enabled for", req.Host, req.URL.Path)
-					}
-
-				}
-
-			} else {
-				// The director found a match.
-
-				if config.static.enable && strings.HasPrefix(root, "/") {
-					// Handle static file requests.
-
-					// we need to modify response
-					// with equivalent of nginx
-					// proxy_redirect /<%= application.name %>/ /;
-					// http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_redirect
-					// // Sets the text that should be changed in the “Location” and “Refresh” header
-					// // fields of a proxied server response.
-					// Otherwise, AWS returned redirects will have wrong paths
-					//
-					// for example
-					// curl -v http://well.127.0.0.1.xip.io:8080/projects/workouts
-					// Location: /well_workout/projects/workouts/
-					// needs to get rewritten to
-					// Location: /projects/workouts/
-					// so
-					// here we set headers so that
-					// in httpwrapper.Transport.RoundTrip we know what's needed to  be replaced
-					req.Header.Add("x-static-root", path.Join(config.static.path, root)+"/")
-					req.Header.Add("x-original-url", req.Host+req.URL.String())
-
-					// Set the URL scheme, host, and path.
-					req.URL.Scheme = config.static.scheme
-					req.URL.Host = config.static.host
-
-					log.Println("Path: ", req.URL.Path)
-					trailing := strings.HasSuffix(req.URL.Path, "/")
-
-					req.URL.Path = path.Join(config.static.path, root, req.URL.Path)
-					if trailing && !strings.HasSuffix(req.URL.Path, "/") {
-						req.URL.Path += "/"
-					}
-
-					// Set the request host (used as the "Host" header value).
-					req.Host = config.static.host
-
-					// Drop cookies given that the response should not vary.
-					req.Header.Del("cookie")
-
-					log.Println("Static:", req.Header.Get("x-original-url"), "to", req.URL.Host+req.URL.Path)
-
-				} else if url := strings.TrimPrefix(root, ">"); url != root {
-					url += req.URL.Path
-					if req.URL.RawQuery != "" {
-						url += "?" + req.URL.RawQuery
-					}
-					//TODO: pass query string along with
-					log.Printf("Redirect: %s%s to %s", req.Host, req.URL.Path, url)
-					http.Redirect(w, req, url, 301)
-					return
-				} else {
-					// Handle an arbitrary URL routing to a service.
-
-					req.URL.Scheme = "http"
-					req.URL.Host = root + kubernetesSuffix
-					log.Println("Proxy:", req.Host+req.URL.Path, "to", req.URL.Host)
-				}
-			}
-
-			reverseProxy.ServeHTTP(w, req)
-		}),
+	log.Println("routes are valid!")
+	if config.ValidateRoutes {
+		return
 	}
 
 	statusServer := &http.Server{
-		Addr: config.statusAddress,
+		Addr: config.StatusAddress,
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprintf(w, "ok")
 		}),
@@ -240,12 +59,12 @@ func main() {
 	errs := make(chan error)
 
 	go func() {
-		log.Println("starting server on", config.address)
+		log.Println("starting server on", config.Address)
 		errs <- mainServer.ListenAndServe()
 	}()
 
 	go func() {
-		log.Println("starting status server on", config.statusAddress)
+		log.Println("starting status server on", config.StatusAddress)
 		errs <- statusServer.ListenAndServe()
 	}()
 

--- a/router/router.go
+++ b/router/router.go
@@ -1,0 +1,227 @@
+package router
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"os"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/newsdev/kubernetes-dns-reverse-proxy/director"
+	"github.com/newsdev/kubernetes-dns-reverse-proxy/httpwrapper"
+)
+
+// Config is a configuration data structure for the router.
+type Config struct {
+	Address, StatusAddress        string
+	DomainSuffixesRaw             string
+	RoutesFilename                string
+	Concurrency, CompressionLevel int
+	Timeout                       time.Duration
+	ValidateRoutes                bool
+
+	Kubernetes KubernetesConfig
+
+	Static   StaticBackendConfig
+	Fallback FallbackConfig
+}
+
+// KubernetesConfig describes properties of the Kubernetes back-end.
+type KubernetesConfig struct {
+	Namespace, DNSDomain string
+}
+
+// StaticBackendConfig describes properties of the static file backend.
+type StaticBackendConfig struct {
+	Enable             bool
+	Scheme, Host, Path string
+}
+
+// FallbackConfig describes properties of the fallback. What's the fallback for?
+type FallbackConfig struct {
+	Enable             bool
+	Scheme, Host, Path string
+}
+
+// DomainSuffixes gets a comma separated list of the service domain suffixes.
+func (c *Config) DomainSuffixes() []string {
+	return strings.Split(c.DomainSuffixesRaw, ",")
+}
+
+// KubernetesServiceDomainSuffix gets the Kubernetes service domain suffix.
+// When appended to a service name, gives a hostname that a service is available on.
+func (c *Config) KubernetesServiceDomainSuffix() string {
+	return fmt.Sprintf(".%s.%s", c.Kubernetes.Namespace, c.Kubernetes.DNSDomain)
+}
+
+// NewKubernetesRouter gives you a router instance.
+func NewKubernetesRouter(config *Config) (*http.Server, error) {
+
+	log.Println("Domain suffixes:", config.DomainSuffixes())
+	log.Println("Kubernetes service domain suffix:", config.KubernetesServiceDomainSuffix())
+
+	// Create a new director object.
+	dir := director.NewDirector()
+
+	// Check for a routes JSON file.
+	if config.ValidateRoutes || config.RoutesFilename != "" {
+
+		routesFile, err := os.Open(config.RoutesFilename)
+		if err != nil {
+			return nil, err
+		}
+
+		routesJSON, err := ioutil.ReadAll(routesFile)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := routesFile.Close(); err != nil {
+			return nil, err
+		}
+
+		var routes map[string]map[string]string
+		if err := json.Unmarshal(routesJSON, &routes); err != nil {
+			return nil, err
+		}
+
+		for domain, prefixMap := range routes {
+			for prefix, service := range prefixMap {
+				dir.SetService(domain, prefix, service)
+			}
+		}
+	}
+
+	// Build the reverse proxy HTTP handler.
+	reverseProxy := &httputil.ReverseProxy{
+		// Specify a custom transport which rate limits requests and compresses responses.
+		Transport: &httpwrapper.Transport{
+			MaxConcurrencyPerHost: config.Concurrency,
+			CompressionLevel:      config.CompressionLevel,
+			Transport: &http.Transport{
+				MaxIdleConnsPerHost: config.Concurrency,
+				Dial: func(network, addr string) (net.Conn, error) {
+					return net.DialTimeout(network, addr, config.Timeout)
+				},
+			},
+		},
+		// The Director has the opportunity to modify the HTTP request before it
+		// is handed off to the Transport.
+		Director: func(req *http.Request) {
+			// empty director atm
+		},
+	}
+
+	return &http.Server{
+			Addr: config.Address,
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				// Drop the connection header to ensure keepalives are maintained.
+				req.Header.Del("connection")
+
+				if root, err := dir.Service(req.Host, req.URL.Path); err != nil {
+					// The director didn't find a match, handle it gracefully.
+
+					if err != director.NoMatchingServiceError {
+						log.Println("Error:", req.Host, req.URL.Path, err)
+					} else {
+
+						// If NoMatchingServiceError is thrown, check against the domain suffixes, e.g. {service}.local
+						for _, domainSuffix := range config.DomainSuffixes() {
+							if root := strings.TrimSuffix(req.Host, domainSuffix); root != req.Host {
+								req.URL.Scheme = "http"
+								req.URL.Host = root + config.KubernetesServiceDomainSuffix()
+								log.Println("Domain Suffix Match:", req.Host, req.URL.Path)
+								reverseProxy.ServeHTTP(w, req)
+								return
+							}
+						}
+
+						// Otherwise, send traffic to the fallback.
+						if config.Fallback.Enable {
+
+							// Set the URL scheme, host, and path.
+							req.URL.Scheme = config.Fallback.Scheme
+							req.URL.Host = config.Fallback.Host
+							req.URL.Path = path.Join(config.Fallback.Path, req.URL.Path)
+
+							log.Println("Fallback:", req.Host, req.URL.Path, "to", req.URL.Host)
+						} else {
+							log.Println("Error: no route matched and fallback not enabled for", req.Host, req.URL.Path)
+						}
+
+					}
+
+				} else {
+					// The director found a match.
+
+					if config.Static.Enable && strings.HasPrefix(root, "/") {
+						// Handle static file requests.
+
+						// we need to modify response
+						// with equivalent of nginx
+						// proxy_redirect /<%= application.name %>/ /;
+						// http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_redirect
+						// // Sets the text that should be changed in the “Location” and “Refresh” header
+						// // fields of a proxied server response.
+						// Otherwise, AWS returned redirects will have wrong paths
+						//
+						// for example
+						// curl -v http://well.127.0.0.1.xip.io:8080/projects/workouts
+						// Location: /well_workout/projects/workouts/
+						// needs to get rewritten to
+						// Location: /projects/workouts/
+						// so
+						// here we set headers so that
+						// in httpwrapper.Transport.RoundTrip we know what's needed to  be replaced
+						req.Header.Add("x-static-root", path.Join(config.Static.Path, root)+"/")
+						req.Header.Add("x-original-url", req.Host+req.URL.String())
+
+						// Set the URL scheme, host, and path.
+						req.URL.Scheme = config.Static.Scheme
+						req.URL.Host = config.Static.Host
+
+						log.Println("Path: ", req.URL.Path)
+						trailing := strings.HasSuffix(req.URL.Path, "/")
+
+						req.URL.Path = path.Join(config.Static.Path, root, req.URL.Path)
+						if trailing && !strings.HasSuffix(req.URL.Path, "/") {
+							req.URL.Path += "/"
+						}
+
+						// Set the request host (used as the "Host" header value).
+						req.Host = config.Static.Host
+
+						// Drop cookies given that the response should not vary.
+						req.Header.Del("cookie")
+
+						log.Println("Static:", req.Header.Get("x-original-url"), "to", req.URL.Host+req.URL.Path)
+
+					} else if url := strings.TrimPrefix(root, ">"); url != root {
+						url += req.URL.Path
+						if req.URL.RawQuery != "" {
+							url += "?" + req.URL.RawQuery
+						}
+						//TODO: pass query string along with
+						log.Printf("Redirect: %s%s to %s", req.Host, req.URL.Path, url)
+						http.Redirect(w, req, url, 301)
+						return
+					} else {
+						// Handle an arbitrary URL routing to a service.
+
+						req.URL.Scheme = "http"
+						req.URL.Host = root + config.KubernetesServiceDomainSuffix()
+						log.Println("Proxy:", req.Host+req.URL.Path, "to", req.URL.Host)
+					}
+				}
+
+				reverseProxy.ServeHTTP(w, req)
+			}),
+		},
+		nil
+}

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -1,0 +1,115 @@
+package router
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+)
+
+type givenReverseProxyRequests struct {
+	URL         string
+	WantHost    string
+	WantHeaders http.Header
+}
+
+func TestRouter(t *testing.T) {
+	tests := []struct {
+		givenRoutesJSON string
+		given           RouterConfig
+		givenRequests   []givenReverseProxyRequests
+	}{
+		{
+			`{
+				"www.cats.com": {
+					"/": "cats"
+				}
+			}`,
+			RouterConfig{
+				"",
+				"",
+				"",
+				"",
+				32,
+				4,
+				time.Second,
+				false,
+				KubernetesConfig{
+					"default",
+					"cluster.local",
+				},
+				StaticBackendConfig{
+					false,
+					"http",
+					"",
+					"/",
+				},
+				FallbackConfig{
+					false,
+					"http",
+					"",
+					"/",
+				},
+			},
+			[]givenReverseProxyRequests{
+				givenReverseProxyRequests{
+					"http://www.cats.com/tabby",
+					"cats.default.cluster.local",
+					http.Header{},
+				},
+				givenReverseProxyRequests{
+					"http://www.cats.com/tabby",
+					"cats.default.cluster.local",
+					http.Header{},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		// Use a temp file for the JSON
+		routefile, err := ioutil.TempFile("", "cats")
+		if err != nil {
+			t.Fatal("we wrote something horrible")
+		}
+		test.given.RoutesFilename = routefile.Name()
+
+		if _, err := routefile.WriteString(test.givenRoutesJSON); err != nil {
+			t.Fatal("we wrote something horrible")
+		}
+		if err := routefile.Close(); err != nil {
+			t.Fatal("we wrote something horrible")
+		}
+
+		for _, givenRequest := range test.givenRequests {
+			router, err := NewKubernetesRouter(&test.given)
+			if err != nil {
+				t.Fatal(err)
+				t.Fatal("Can't create router")
+			}
+			request, err := http.NewRequest("GET", givenRequest.URL, nil)
+			if err != nil {
+				t.Fatal("bad given test URL")
+			}
+
+			// Save the URL for later.
+			request.Header.Add("X-Original-URL", request.URL.String())
+
+			// Add a connection header, which the ReverseProxy should drop.
+			request.Header.Add("connection", "glerf")
+
+			responseRecorder := httptest.NewRecorder()
+			router.Handler.ServeHTTP(responseRecorder, request)
+			if request.URL.Host != givenRequest.WantHost {
+				t.Errorf("The router should have rewritten the request %s to %s, but it was mapped to %s", request.Header.Get("X-Original-URL"), givenRequest.WantHost, request.URL.Host)
+			}
+			if request.Header.Get("connection") != "" {
+				t.Error("The router should drop the connection header, it did not.")
+			}
+		}
+		os.Remove(routefile.Name())
+
+	}
+}


### PR DESCRIPTION
This is a work-in-progress for refactoring `master` with the work we put into making the reverse proxy testable. Feedback welcome :smile: 

We have one test, checking the `connection` header is dropped.

We should be able to test service DNS mapping, rewrites and fallback functionality. This testing can happen without spinning up back-ends by inspecting how the request object is modified after the router serves HTTP.

Let's consider testing those pieces of functionality the bare minimum for a merge. Am I missing anything?

Currently running tests will fail because of a syntax error. 

```
./router_test.go:40: Config.Kubernetes undefined (type Config has no method Kubernetes)
./router_test.go:44: Config.Static undefined (type Config has no method Static)
./router_test.go:50: Config.Fallback undefined (type Config has no method Fallback)
```

This has to do with how [I'm creating the test objects](https://github.com/newsdev/kubernetes-dns-reverse-proxy/compare/testing?expand=1#diff-c28162c53e5099227a046f2220dedb3eR40). @buth — is there something I should be aware of in creating anonymous type instances like this? I know we ran into this before, which led us to [creating a separate givenReverseProxyRequests type](https://github.com/newsdev/kubernetes-dns-reverse-proxy/compare/testing?expand=1#diff-c28162c53e5099227a046f2220dedb3eR13). 
